### PR TITLE
Fix TOTP flow + JSON decode for Proton export

### DIFF
--- a/proton_to_keepass/__main__.py
+++ b/proton_to_keepass/__main__.py
@@ -12,7 +12,7 @@ converter.decrypt_file_to_json()
 keepManager = KeePassManager(config)
 
 if config.separate_totp:
-  keepManagerTotp = KeePassManager(config)
+  keepManagerTotp = KeePassManager(config, totp=True)
 
 group = keepManager.root
 for (_, vault) in converter.vaults:
@@ -27,7 +27,7 @@ for (_, vault) in converter.vaults:
       print(f"   Converted {entry.name}!")
 
     if config.separate_totp and entry.totp:
-      keepManagerTotp.add_entry(entry)
+      keepManagerTotp.add_entry(keepManagerTotp.root, entry)
       if config.verbose:
         print(f"   Separated {entry.name} TOTP!")
 
@@ -39,4 +39,4 @@ print(f"   Successfully converted {len(converter.vaults)} vaults!")
 print(f"   Saved to {os.path.abspath(f'{config.output_file_path}/{config.output_file_name}')}!")
 
 if config.separate_totp:
-  print(f"   Saved TOTP to {os.path.abspath(f'{config.totp_output_file_path}/{config.totp_output_file_name}')}!")
+  print(f"   Saved TOTP to {os.path.abspath(f'{config.totp_output_path}/{config.totp_output_name}')}!")

--- a/proton_to_keepass/config.py
+++ b/proton_to_keepass/config.py
@@ -75,10 +75,10 @@ class Config():
     self.gather_output_info()
 
     self._merge_vaults = input("Merge vaults into root folder? (default: n) (y/n): ")
-    self._separate_totp = input("Separate your TOTP/2FA into their own file? (default: n) (y/n): ") or False
+    separate_totp = input("Separate your TOTP/2FA into their own file? (default: n) (y/n): ").strip().lower()
+    self._separate_totp = separate_totp == "y"
 
-    if self._separate_totp == "y":
-      self.separate_totp = True
+    if self._separate_totp:
       self.initialize_totp_db()
 
   def gather_input_info(self):
@@ -108,15 +108,15 @@ class Config():
 
   def initialize_totp_db(self):
     default_totp_filename = f"./pp_convert_totp_{self._timestamp}.kdbx"
-    self._totp_output_name = input(f"Desired name for output TOTP KDBX file ({default_totp_filename}): ") or default_totp_filename
-    self._totp_output_path = input(f"Desired path for output TOTP KDBX file ({self._cwd}): ") or self._cwd
-    self._kdbx_totp_pass = getpass("Password for TOTP KDBX: ")
-    if self._kdbx_totp_pass == self._kdbx_pass:
+    self._totp_output_file_name = input(f"Desired name for output TOTP KDBX file ({default_totp_filename}): ") or default_totp_filename
+    self._totp_output_file_path = input(f"Desired path for output TOTP KDBX file ({self._cwd}): ") or self._cwd
+    self._totp_output_file_passkey = getpass("Password for TOTP KDBX: ") or ""
+    if self._totp_output_file_passkey == self._output_file_passkey:
       diff_pass = input("   Using the same password is not as secure as using different passwords. Use different password? (y/n): ")
       if diff_pass == "y":
-        self._kdbx_totp_pass = getpass("Password for TOTP KDBX: ")
-        if self._kdbx_totp_pass == "":
-          self._kdbx_totp_pass = self.empty_input_handler("Password for TOTP KDBX", "Error: No password provided.", allow_ignore=True)
+        self._totp_output_file_passkey = getpass("Password for TOTP KDBX: ") or ""
+        if self._totp_output_file_passkey == "":
+          self._totp_output_file_passkey = self.empty_input_handler("Password for TOTP KDBX", "Error: No password provided.", allow_ignore=True)
   
   def get_new_timestamp(self):
     return datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")[:-3]
@@ -151,15 +151,15 @@ class Config():
   
   @property
   def totp_output_path(self):
-    return self._totp_output_path
+    return self._totp_output_file_path
   
   @property
   def totp_output_name(self):
-    return self._totp_output_name
+    return self._totp_output_file_name
   
   @property
   def totp_output_passkey(self):
-    return self._totp_output_passkey
+    return self._totp_output_file_passkey
 
   @property
   def encrypted_file_passkey(self):

--- a/proton_to_keepass/converter.py
+++ b/proton_to_keepass/converter.py
@@ -1,8 +1,5 @@
 import gnupg
 import json
-import re
-import sys
-from datetime import datetime
 from proton_to_keepass.entry import Entry
 from proton_to_keepass.config import Config
 
@@ -15,21 +12,24 @@ class Converter():
     self.vaults = None
   
   def decrypt_file_to_json(self):
-    self.decrypted_file = self.gpg.decrypt_file(self.filepath, passphrase=self.passphrase)
-    if self.decrypted_file.status == "bad passphrase" or self.decrypted_file.status == "decryption failed":
-      print(f"   GnuPG Status: {self.decrypted_file.status}")
+    decrypted_result = self.gpg.decrypt_file(self.filepath, passphrase=self.passphrase)
+    if decrypted_result.status == "bad passphrase" or decrypted_result.status == "decryption failed":
+      print(f"   GnuPG Status: {decrypted_result.status}")
       print("   Error: Possible bad passphrase, try again.")
       exit()
 
-    self.strip_junk()
-    self.decrypted_file = self.decrypted_file.decode("utf-8") + "}"
-    self.decrypted_file = json.loads(self.decrypted_file)
+    cleaned_text = self.strip_junk(decrypted_result.data)
+    decoder = json.JSONDecoder()
+    self.decrypted_file, _ = decoder.raw_decode(cleaned_text)
     self.vaults = self.decrypted_file["vaults"].items()
 
-  def strip_junk(self):
-    front_binaries_pattern = re.compile(rb'}PK.+', flags=re.DOTALL)
-    back_binaries_pattern = re.compile(rb'^[^{]*', flags=re.DOTALL)
-    self.decrypted_file = re.sub(front_binaries_pattern, b'', re.sub(back_binaries_pattern, b'', self.decrypted_file.data))
+  def strip_junk(self, raw_bytes):
+    text = raw_bytes.decode("utf-8", errors="ignore")
+    start = text.find("{")
+    if start == -1:
+      print("   Error: Unable to locate JSON in decrypted file.")
+      exit()
+    return text[start:]
 
   def create_entry(self, entry):
     return Entry(entry)

--- a/proton_to_keepass/kp_manager.py
+++ b/proton_to_keepass/kp_manager.py
@@ -4,9 +4,9 @@ from proton_to_keepass.config import Config
 class KeePassManager():
   def __init__(self, config: Config, totp=False):
     self._config = config
-    self._output_path = config.output_file_path if not totp else config.totp_output_file_path
-    self._output_name = config.output_file_name if not totp else config.totp_output_file_name
-    self._passkey = config.output_file_passkey if not totp else config.totp_output_file_passkey
+    self._output_path = config.output_file_path if not totp else config.totp_output_path
+    self._output_name = config.output_file_name if not totp else config.totp_output_name
+    self._passkey = config.output_file_passkey if not totp else config.totp_output_passkey
     self._db = pykeepass.create_database(f'{self._output_path}/{self._output_name}', password=self._passkey)
   
   @property


### PR DESCRIPTION
**Summary:**  
This PR fixes two crashes and corrects the TOTP wiring.

**Changes:**

- Treat separate_totp as a boolean flag and avoid assigning to the read‑only property.
- Fix TOTP output variable naming so config values are actually used.
- Create KeePassManager with totp=True when separating TOTP and call add_entry() with the correct signature.
- Parse decrypted JSON with JSONDecoder().raw_decode() after stripping leading junk, instead of appending } and calling json.loads() (avoids Extra data).

**Why:**

- AttributeError when choosing TOTP separation.
- JSONDecodeError: Extra data on normal runs due to trailing bytes in the decrypted payload.

**Tested:**

- TOTP separation: success, main KDBX + TOTP KDBX created.
- No TOTP separation: success.