### PR TITLE
Ignore local venv and VSCode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@ __pycache__/
 # C extensions
 *.so
 
+# Virtual environment
+.venv/
+
+# VSCode / VSCodium
+.vscode/
+.history/
+
 # Distribution / packaging
 bin/
 build/


### PR DESCRIPTION
## Summary
Add local development artifacts to .gitignore.

## Changes
- ignore `.venv/`
- ignore VSCode/VSCodium directories: `.vscode/` and `.history/`

## Notes
No runtime or functional changes; housekeeping only.